### PR TITLE
Bump ember-auto-import to v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ package-lock.json
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# tools
+.idea

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-cli-babel": "^7.23.0",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-mu-transform-helpers": "^2.0.0",
-    "ember-auto-import": "^1.10.1",
+    "ember-auto-import": "^2.2.2",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -70,7 +70,8 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
     "qunit": "^2.13.0",
-    "qunit-dom": "^1.6.0"
+    "qunit-dom": "^1.6.0",
+    "webpack": "^5.58.2"
   },
   "peerDepencies": {
     "ember-concurrency": "*",


### PR DESCRIPTION
we should do this for all our addons

main reason here is to allow it do depend on ember-rdfa-editor for its dummy-app so we can test in isolation